### PR TITLE
ci: test against Rails 7.2, 8.0, and 8.1 beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}
     strategy:
+      fail-fast: false
       matrix:
         ruby:
           - "3.4.4"
+        rails:
+          - "7.2.0"
+          - "8.0.2"
+          - "8.1.0.beta1"
+    env:
+      ACTIVERECORD_VERSION: ${{ matrix.rails }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Add matrix testing for Rails 7.2.0, 8.0.2, and 8.1.0.beta1
- Use existing ACTIVERECORD_VERSION environment variable from Gemfile
- Set fail-fast: false to test all versions even if one fails
- Update job names to include Rails version for clarity