### PR TITLE
fix: implement hard_reset event for proper test isolation

### DIFF
--- a/lib/breaker_machines/circuit/async_state_management.rb
+++ b/lib/breaker_machines/circuit/async_state_management.rb
@@ -36,6 +36,16 @@ module BreakerMachines
             transition any => :closed
           end
 
+          event :hard_reset do
+            transition any => :closed
+          end
+
+          before_transition on: :hard_reset do |circuit|
+            circuit.storage.clear(circuit.name) if circuit.storage
+            circuit.half_open_attempts.value = 0
+            circuit.half_open_successes.value = 0
+          end
+
           # Async-safe callbacks using modern API
           after_transition to: :open do |circuit|
             circuit.send(:on_circuit_open)

--- a/lib/breaker_machines/circuit/coordinated_state_management.rb
+++ b/lib/breaker_machines/circuit/coordinated_state_management.rb
@@ -34,6 +34,16 @@ module BreakerMachines
             transition any => :closed
           end
 
+          event :hard_reset do
+            transition any => :closed
+          end
+
+          before_transition on: :hard_reset do |circuit|
+            circuit.storage.clear(circuit.name) if circuit.storage
+            circuit.half_open_attempts.value = 0
+            circuit.half_open_successes.value = 0
+          end
+
           after_transition to: :open do |circuit|
             circuit.send(:on_circuit_open)
           end

--- a/lib/breaker_machines/circuit/state_management.rb
+++ b/lib/breaker_machines/circuit/state_management.rb
@@ -31,6 +31,16 @@ module BreakerMachines
             transition any => :closed
           end
 
+          event :hard_reset do
+            transition any => :closed
+          end
+
+          before_transition on: :hard_reset do |circuit|
+            circuit.storage.clear(circuit.name) if circuit.storage
+            circuit.half_open_attempts.value = 0
+            circuit.half_open_successes.value = 0
+          end
+
           after_transition to: :open do |circuit|
             circuit.send(:on_circuit_open)
           end

--- a/lib/breaker_machines/dsl.rb
+++ b/lib/breaker_machines/dsl.rb
@@ -122,7 +122,7 @@ module BreakerMachines
         instance_registry.each do |weak_ref|
           instance = weak_ref.__getobj__
           circuit_instances = instance.instance_variable_get(:@circuit_instances)
-          circuit_instances&.each_value(&:force_close!)
+          circuit_instances&.each_value(&:hard_reset!)
         rescue WeakRef::RefError
           # Instance was garbage collected, skip it
         end
@@ -262,7 +262,7 @@ module BreakerMachines
 
     # Reset all circuits for this instance
     def reset_all_circuits
-      circuit_instances.each_value(&:force_close!)
+      circuit_instances.each_value(&:hard_reset!)
     end
 
     # Remove a global dynamic circuit by name

--- a/test/introspection_test.rb
+++ b/test/introspection_test.rb
@@ -35,9 +35,14 @@ class IntrospectionTest < ActiveSupport::TestCase
   end
 
   def setup
-    @module = DiagnosticModule.new
-    # Clear registry to start fresh
+    # Clear registry first
     BreakerMachines::Registry.instance.clear
+    
+    # Reset at class level to catch any prior instances
+    DiagnosticModule.reset_all_circuits
+    
+    # Create fresh instance
+    @module = DiagnosticModule.new
   end
 
   def test_circuit_stats

--- a/test/reset_test.rb
+++ b/test/reset_test.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ResetTest < ActiveSupport::TestCase
+  class TestModule
+    include BreakerMachines::DSL
+
+    circuit :api_call do
+      threshold failures: 2, within: 10
+      half_open_requests 3  # Need multiple requests to close from half-open
+    end
+
+    def make_api_call(&)
+      circuit(:api_call).call(&)
+    end
+  end
+
+  def test_reset_all_circuits_clears_failure_counts
+    instance = TestModule.new
+    
+    # Trigger failures to open circuit
+    2.times do
+      assert_raises(RuntimeError) do
+        instance.make_api_call { raise 'API error' }
+      end
+    end
+    
+    # Circuit should be open
+    assert_raises(BreakerMachines::CircuitOpenError) do
+      instance.make_api_call { 'success' }
+    end
+    
+    # Reset all circuits
+    instance.reset_all_circuits
+    
+    # Circuit should be closed and failure count cleared
+    circuit = instance.circuit(:api_call)
+    assert_predicate circuit, :closed?
+    assert_equal 0, circuit.stats.failure_count
+    
+    # Should be able to trigger one failure without opening
+    assert_raises(RuntimeError) do
+      instance.make_api_call { raise 'API error' }
+    end
+    
+    # Circuit should still be closed (only 1 failure, threshold is 2)
+    assert_predicate circuit, :closed?
+    
+    # Second failure should open it
+    assert_raises(RuntimeError) do
+      instance.make_api_call { raise 'API error' }
+    end
+    
+    # Now circuit should be open
+    assert_predicate circuit, :open?
+  end
+
+  def test_class_level_reset_affects_all_instances
+    instance1 = TestModule.new
+    instance2 = TestModule.new
+    
+    # Open circuits on both instances
+    [instance1, instance2].each do |instance|
+      2.times do
+        assert_raises(RuntimeError) do
+          instance.make_api_call { raise 'Error' }
+        end
+      end
+    end
+    
+    # Both should be open
+    assert_predicate instance1.circuit(:api_call), :open?
+    assert_predicate instance2.circuit(:api_call), :open?
+    
+    # Class-level reset
+    TestModule.reset_all_circuits
+    
+    # Both should be closed with cleared counts
+    assert_predicate instance1.circuit(:api_call), :closed?
+    assert_predicate instance2.circuit(:api_call), :closed?
+    assert_equal 0, instance1.circuit(:api_call).stats.failure_count
+    assert_equal 0, instance2.circuit(:api_call).stats.failure_count
+  end
+
+  def test_hard_reset_clears_half_open_counters
+    instance = TestModule.new
+    
+    # Open the circuit
+    2.times do
+      assert_raises(RuntimeError) do
+        instance.make_api_call { raise 'Error' }
+      end
+    end
+    
+    # Force to half-open to test counter reset
+    circuit = instance.circuit(:api_call)
+    circuit.attempt_recovery!
+    
+    # The counters might be incremented during half-open operation
+    # but the key test is that hard_reset! clears them
+    
+    # Hard reset should clear these counters
+    circuit.hard_reset!
+    
+    assert_equal 0, circuit.half_open_attempts.value
+    assert_equal 0, circuit.half_open_successes.value
+    assert_predicate circuit, :closed?
+  end
+
+  def test_hard_reset_vs_force_close_behavior
+    instance = TestModule.new
+    
+    # Trigger one failure
+    assert_raises(RuntimeError) do
+      instance.make_api_call { raise 'Error' }
+    end
+    
+    circuit = instance.circuit(:api_call)
+    assert_equal 1, circuit.stats.failure_count
+    
+    # force_close! should not clear failure count
+    circuit.force_close!
+    assert_equal 1, circuit.stats.failure_count
+    
+    # Trigger one more failure should open it (total 2)
+    assert_raises(RuntimeError) do
+      instance.make_api_call { raise 'Error' }
+    end
+    assert_predicate circuit, :open?
+    
+    # hard_reset! should clear failure count
+    circuit.hard_reset!
+    assert_equal 0, circuit.stats.failure_count
+    assert_predicate circuit, :closed?
+    
+    # Should be able to trigger one failure without opening again
+    assert_raises(RuntimeError) do
+      instance.make_api_call { raise 'Error' }
+    end
+    assert_predicate circuit, :closed? # Still closed because count was reset
+  end
+
+  def test_hard_reset_clears_storage_completely
+    instance = TestModule.new
+    
+    # Generate some history
+    instance.make_api_call { 'success' } # 1 success
+    assert_raises(RuntimeError) { instance.make_api_call { raise 'Error' } } # 1 failure
+    
+    circuit = instance.circuit(:api_call)
+    stats = circuit.stats
+    
+    assert_equal 1, stats.success_count
+    assert_equal 1, stats.failure_count
+    
+    # Hard reset should clear all storage
+    circuit.hard_reset!
+    
+    stats = circuit.stats
+    assert_equal 0, stats.success_count
+    assert_equal 0, stats.failure_count
+    assert_predicate circuit, :closed?
+  end
+end


### PR DESCRIPTION
## Summary

Fixes test isolation issue where circuits retained failure counts between tests, causing `RuntimeError` expectations to fail with `CircuitOpenError` instead.

The root cause was that `force_close!` only transitions circuit state but doesn't clear failure counts in storage. With shared storage between tests, cumulative failure counts caused circuits to immediately open on subsequent test failures.

## Changes

- **Add `hard_reset` event** to all state management modules (`state_management.rb`, `async_state_management.rb`, `coordinated_state_management.rb`)
- **State machine callback approach**: Uses `before_transition on: :hard_reset` callback to clear storage and counters
- **Update DSL methods**: `reset_all_circuits` now uses `hard_reset!` instead of `force_close!`
- **Fix test setup**: Updated introspection test to reset at class level before creating instances
- **Comprehensive regression tests** in `test/reset_test.rb`

## Technical Details

The `hard_reset` event:
- Transitions circuit to `:closed` state (like `force_close`)
- **Clears storage**: `circuit.storage.clear(circuit.name)` 
- **Resets counters**: `half_open_attempts` and `half_open_successes` to 0
- Uses proper state machine callbacks instead of manual post-processing

## Test Results

- ✅ Fixes seed 46709 test failures in `introspection_test.rb`
- ✅ All existing tests pass with various seeds
- ✅ New regression tests verify reset behavior
- ✅ Clean test isolation regardless of execution order

## Test Plan

- [x] Run failing tests with seed 46709 - now passes
- [x] Run full test suite with problematic seed - all pass
- [x] Verify `hard_reset!` vs `force_close!` behavior differences
- [x] Test class-level and instance-level reset methods
- [x] Verify storage clearing and counter reset functionality